### PR TITLE
Add custom labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "prometheus-api-metrics",
-  "version": "2.2.3",
+  "name": "@rmberne/prometheus-api-metrics",
+  "version": "1.0.0",
   "description": "API and process monitoring with Prometheus for Node.js micro-service",
-  "author": "Idan Tovi",
+  "author": "Idan Tovi / Rafael Berne",
   "scripts": {
     "unit-tests": "nyc mocha ./test/unit-test/*-test.js",
     "no-koa-test": "nyc mocha ./test/unit-test/*-test.js ./test/integration-tests/express/*-test.js --require ts-node/register test/integration-tests/nest-js/*.spec.ts",
@@ -85,7 +85,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Zooz/prometheus-api-metrics.git"
+    "url": "git+https://github.com/rmberne/prometheus-api-metrics.git"
   },
   "keywords": [
     "monitoring",
@@ -99,7 +99,7 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Zooz/prometheus-api-metrics/issues"
+    "url": "https://github.com/rmberne/prometheus-api-metrics/issues"
   },
-  "homepage": "https://github.com/Zooz/prometheus-api-metrics#readme"
+  "homepage": "https://github.com/rmberne/prometheus-api-metrics#readme"
 }

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -10,12 +10,14 @@ const setupOptions = {};
 
 module.exports = (appVersion, projectName, framework = 'express') => {
     return (options = {}) => {
-        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes, includeQueryParams } = options;
+        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes, includeQueryParams, customLabels = [], customLabelsResolver } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
         setupOptions.metricsRoute = metricsPath || '/metrics';
         setupOptions.excludeRoutes = excludeRoutes || [];
         setupOptions.includeQueryParams = includeQueryParams;
         setupOptions.defaultMetricsInterval = defaultMetricsInterval;
+        setupOptions.customLabels = customLabels;
+        setupOptions.customLabelsResolver = customLabelsResolver || function () { return { } };
 
         let metricNames = {
             http_request_duration_seconds: 'http_request_duration_seconds',
@@ -42,7 +44,7 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         setupOptions.responseTimeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_duration_seconds) || new Prometheus.Histogram({
             name: metricNames.http_request_duration_seconds,
             help: 'Duration of HTTP requests in seconds',
-            labelNames: ['method', 'route', 'code'],
+            labelNames: ['method', 'route', 'code', ...customLabels],
             // buckets for response time from 1ms to 500ms
             buckets: durationBuckets || [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
         });
@@ -50,14 +52,14 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         setupOptions.requestSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_request_size_bytes,
             help: 'Size of HTTP requests in bytes',
-            labelNames: ['method', 'route', 'code'],
+            labelNames: ['method', 'route', 'code', ...customLabels],
             buckets: requestSizeBuckets || [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000] // buckets for response time from 5 bytes to 10000 bytes
         });
 
         setupOptions.responseSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_response_size_bytes,
             help: 'Size of HTTP response in bytes',
-            labelNames: ['method', 'route', 'code'],
+            labelNames: ['method', 'route', 'code', ...customLabels],
             buckets: responseSizeBuckets || [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000] // buckets for response time from 5 bytes to 10000 bytes
         });
 

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -571,5 +571,36 @@ describe('metrics-middleware', () => {
                 });
             });
         });
+        after(() => {
+            Prometheus.register.clear();
+        });
+    });
+    describe('when calling the function without options (customLabels, customLabelsResolver)', () => {
+        before(() => {
+            middleware({
+                customLabels: ['myCustomLabel']
+            });
+        });
+        it('should have http_request_size_bytes metrics with default buckets', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').bucketValues).to.have.all.keys([5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]);
+        });
+        it('should have http_request_size_bytes with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'myCustomLabel']);
+        });
+        it('should have http_request_duration_seconds metrics with default buckets', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_duration_seconds').bucketValues).to.have.all.keys([0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]);
+        });
+        it('should have http_request_duration_seconds with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_duration_seconds').labelNames).to.have.members(['method', 'route', 'code', 'myCustomLabel']);
+        });
+        it('should have http_response_size_bytes metrics with default buckets', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes').bucketValues).to.have.all.keys([5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]);
+        });
+        it('should have http_response_size_bytes with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'myCustomLabel']);
+        });
+        after(() => {
+            Prometheus.register.clear();
+        });
     });
 });


### PR DESCRIPTION
Make it possible to add custom labels (ie headers or something resolved realtime).

This implementation assumes that whenever a custom label is specified then a resolver will be also provided in order to fetch this label value.